### PR TITLE
patch the memcache crate to make it usable

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Experimental support for connection timeout,
+    and fractional timeouts (gh#1, gh#9)
 
 0.01      2022-10-25 07:32:27 -0600
   - initial version
-
-

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ The following schemes are supported:
 You can append these query parameters
 to the URL:
 
+- `connect_timeout`
+
+    **Experimental**: Connect timeout in seconds.  May be specified as a
+    floating point, that is `0.2` is 20 milliseconds.
+
 - `protocol`
 
     If set to `ascii` this will use the ASCII protocol instead of binary.
@@ -68,6 +73,9 @@ to the URL:
 - `timeout`
 
     IO timeout in seconds.
+
+    **Experimental**: May be specified as a 
+    floating point, that is `0.2` is 20 milliseconds.
 
 - `verify_mode`
 

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -123,8 +123,7 @@ dependencies = [
 [[package]]
 name = "memcache"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757b4de02817c63ff4efc98a282b305977a7468b2bdf2085c140cdab1604fa61"
+source = "git+https://github.com/plicease-pr/rust-memcache?branch=graham/fractional-timeout#0731815232fed5339ab2148437a8a0c415ab226c"
 dependencies = [
  "byteorder",
  "enum_dispatch",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -9,3 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 memcache = "0.16.0"
 anyhow = "1.0.65"
+
+[patch.crates-io]
+# https://github.com/aisk/rust-memcache/pull/135
+memcache = { git = 'https://github.com/plicease-pr/rust-memcache', branch = 'graham/fractional-timeout' }

--- a/lib/Memcached/RateLimit.pm
+++ b/lib/Memcached/RateLimit.pm
@@ -114,6 +114,11 @@ to the URL:
 
 =over 4
 
+=item C<connect_timeout>
+
+B<Experimental>: Connect timeout in seconds.  May be specified as a
+floating point, that is C<0.2> is 20 milliseconds.
+
 =item C<protocol>
 
 If set to C<ascii> this will use the ASCII protocol instead of binary.
@@ -125,6 +130,9 @@ Boolean C<true> or C<false>.
 =item C<timeout>
 
 IO timeout in seconds.
+
+B<Experimental>: May be specified as a 
+floating point, that is C<0.2> is 20 milliseconds.
 
 =item C<verify_mode>
 

--- a/t/memcached_ratelimit.t
+++ b/t/memcached_ratelimit.t
@@ -48,7 +48,7 @@ subtest_streamed 'live tests' => sub {
       $port ||= 11211;
 
       # note: connect_timeout not yet recognized, but hopefully will be soon
-      my $url = "$scheme{$name}://$host:$port?timeout=2&connect_timeout=2";
+      my $url = "$scheme{$name}://$host:$port?timeout=5.5&connect_timeout=5.5";
       $url .= "&verify_mode=none" if $name eq 'tls';
       note "using $url";
 


### PR DESCRIPTION
This uses a patched version of the memcache crate that has:

 1. support for setting a connection timeout
 2. support for fractional timeouts